### PR TITLE
fixing invoke-dscresourcetest support with Pester5

### DIFF
--- a/source/Public/Get-DscResourceTestContainer.ps1
+++ b/source/Public/Get-DscResourceTestContainer.ps1
@@ -25,7 +25,8 @@ function Get-DscResourceTestContainer
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
+        [AllowNull()]
         [System.String]
         $ProjectPath,
 
@@ -37,7 +38,8 @@ function Get-DscResourceTestContainer
         [System.String]
         $DefaultBranch,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
+        [AllowNull()]
         [System.String]
         $SourcePath,
 

--- a/source/Public/Invoke-DscResourceTest.ps1
+++ b/source/Public/Invoke-DscResourceTest.ps1
@@ -7,20 +7,15 @@ function Invoke-DscResourceTest
     [CmdletBinding(DefaultParameterSetName = 'ByProjectPath')]
     param
     (
-        # [Parameter(Mandatory = $true, ParameterSetName = 'Pester5', Position = 0)]
-        # [System.String]
-        # $v5,
-
-        [Parameter(ParameterSetName = 'ByModuleNameOrPath', Position = 0)]
+        [Parameter(ParameterSetName = 'ByModuleNameOrPath', Mandatory = $true, Position = 0)]
         [System.String]
         $Module,
 
-        [Parameter(ParameterSetName = 'ByModuleSpecification', Position = 0)]
+        [Parameter(ParameterSetName = 'ByModuleSpecification', Mandatory = $true, Position = 0)]
         [Microsoft.PowerShell.Commands.ModuleSpecification]
         $FullyQualifiedModule,
 
-        [Parameter(ParameterSetName = 'ByProjectPath', Position = 0)]
-        [Parameter(Mandatory = $true, ParameterSetName = 'Pester5')]
+        [Parameter(ParameterSetName = 'ByProjectPath', Mandatory = $true, Position = 0)]
         [System.String]
         $ProjectPath,
 
@@ -42,20 +37,19 @@ function Invoke-DscResourceTest
         [Parameter(ParameterSetName = 'ByModuleSpecification', Position = 3)]
         [Parameter(ParameterSetName = 'ByProjectPath', Position = 3)]
         [System.Management.Automation.SwitchParameter]
-        $EnableExit,
+        $EnableExit, #v4
 
         [Parameter(ParameterSetName = 'ByModuleNameOrPath', Position = 5)]
         [Parameter(ParameterSetName = 'ByModuleSpecification', Position = 5)]
         [Parameter(ParameterSetName = 'ByProjectPath', Position = 5)]
-        [Parameter(ParameterSetName = 'Pester5')]
         [Alias('Tags','Tag')]
         [System.String[]]
-        $TagFilter,
+        $TagFilter, #v4 Filter.Tag
 
         [Parameter()]
         [Alias('ExcludeTag')]
         [System.String[]]
-        $ExcludeTagFilter,
+        $ExcludeTagFilter,  #v4 Filter.ExcludeTag
 
         [Parameter()]
         [System.String[]]
@@ -73,339 +67,347 @@ function Invoke-DscResourceTest
         [Parameter(ParameterSetName = 'ByModuleSpecification')]
         [Parameter(ParameterSetName = 'ByProjectPath')]
         [System.Object[]]
-        $CodeCoverage,
+        $CodeCoverage,  #v4 CodeCoverage.Enabled = $true
 
         [Parameter(ParameterSetName = 'ByModuleNameOrPath')]
         [Parameter(ParameterSetName = 'ByModuleSpecification')]
         [Parameter(ParameterSetName = 'ByProjectPath')]
         [System.String]
-        $CodeCoverageOutputFile,
+        $CodeCoverageOutputFile,  #v4
 
         [Parameter(ParameterSetName = 'ByModuleNameOrPath')]
         [Parameter(ParameterSetName = 'ByModuleSpecification')]
         [Parameter(ParameterSetName = 'ByProjectPath')]
         [ValidateSet('JaCoCo')]
         [System.String]
-        $CodeCoverageOutputFileFormat,
+        $CodeCoverageOutputFileFormat, #v4 CodeCoverage.CodeCoverageOutputFileFormat = 'JaCoCo'
 
         [Parameter(ParameterSetName = 'ByModuleNameOrPath')]
         [Parameter(ParameterSetName = 'ByModuleSpecification')]
         [Parameter(ParameterSetName = 'ByProjectPath')]
         [System.Management.Automation.SwitchParameter]
-        $Strict,
+        $Strict, #v4
 
         [Parameter()]
         [System.String]
-        $Output,
+        $Output, #v4
 
         [Parameter(ParameterSetName = 'ByModuleNameOrPath')]
         [Parameter(ParameterSetName = 'ByModuleSpecification')]
         [Parameter(ParameterSetName = 'ByProjectPath')]
         [System.String]
-        $OutputFile,
+        $OutputFile, #v4 TestResult.OutputFile
 
         [Parameter(ParameterSetName = 'ByModuleNameOrPath')]
         [Parameter(ParameterSetName = 'ByModuleSpecification')]
         [Parameter(ParameterSetName = 'ByProjectPath')]
         [ValidateSet('NUnitXml', 'JUnitXml')]
         [System.String]
-        $OutputFormat,
+        $OutputFormat, #v4 TestResult.OutputFormat
 
         [Parameter(ParameterSetName = 'ByModuleNameOrPath')]
         [Parameter(ParameterSetName = 'ByModuleSpecification')]
         [Parameter(ParameterSetName = 'ByProjectPath')]
         [System.Management.Automation.SwitchParameter]
-        $Quiet,
+        $Quiet, #v4 $Show = 'none'
 
         [Parameter(ParameterSetName = 'ByModuleNameOrPath')]
         [Parameter(ParameterSetName = 'ByModuleSpecification')]
         [Parameter(ParameterSetName = 'ByProjectPath')]
         [System.Object]
-        $PesterOption,
+        $PesterOption, #v4
 
         [Parameter(ParameterSetName = 'ByModuleNameOrPath')]
         [Parameter(ParameterSetName = 'ByModuleSpecification')]
         [Parameter(ParameterSetName = 'ByProjectPath')]
         [Pester.OutputTypes]
-        $Show,
+        $Show, #v4 Output.Verbosity Default,Passed,Failed,Pending,Skipped,Inconclusive,Describe,Context,Summary,Header,All,Fails
 
         [Parameter(ParameterSetName = 'ByModuleNameOrPath')]
         [Parameter(ParameterSetName = 'ByModuleSpecification')]
         [Parameter(ParameterSetName = 'ByProjectPath')]
-        [System.Collections.Hashtable]
+        [System.Collections.IDictionary]
+        [Alias('Configuration')]
         $Settings,
 
         [Parameter(ParameterSetName = 'ByModuleNameOrPath')]
         [Parameter(ParameterSetName = 'ByModuleSpecification')]
         [Parameter(ParameterSetName = 'ByProjectPath')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'Pester5')]
         [System.String]
         $MainGitBranch = 'master',
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'Pester5')]
-        [System.String]
-        $ModuleName,
-
-        [Parameter(Mandatory = $true, ParameterSetName = 'Pester5')]
-        [System.String]
-        $SourcePath,
-
-        [Parameter(Mandatory = $true, ParameterSetName = 'Pester5')]
-        [System.String]
-        $ModuleBase
+        [Parameter(ParameterSetName = 'ByModuleNameOrPath', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ByModuleSpecification', DontShow = $true)]
+        [Parameter(ParameterSetName = 'ByProjectPath', DontShow = $true)]
+        [System.Management.Automation.SwitchParameter]
+        $Pesterv5 = $(
+            if ( # Pester 5 is loaded, or we don't have pester 4 loaded and 5 is available
+                (Get-Module -FullyQualifiedName @{ModuleName = 'Pester'; ModuleVersion = '5.0'}) -or
+                (-not (Get-Module -FullyQualifiedName @{ModuleName = 'Pester'; MaximumVersion = '4.99'}) -and (Get-Module -ListAvailable -FullyQualifiedName @{ModuleName = 'Pester'; ModuleVersion = '5.0'} ))
+            )
+            {
+                $true
+            }
+            else
+            {
+                $false
+            }
+        )
     )
 
     begin
     {
-        if ($PSCmdlet.ParameterSetName -ne 'Pester5')
+
+        switch ($PSCmdlet.ParameterSetName)
         {
-            <#
-                Run old Pester 4 workflow.
-
-                Make sure Invoke-DscResourceTest runs against the Built Module either:
-
-                By $Module (Name, Path, ModuleSpecification): enables to run some tests on installed modules (even without source)
-                By $ProjectPath (detect source from there based on .psd1): Target both the source when relevant and the expected files
-            #>
-
-            switch ($PSCmdlet.ParameterSetName)
+            'ByModuleNameOrPath'
             {
-                'ByModuleNameOrPath'
+                Write-Verbose -Message 'Calling DscResource Test by Module Name (or Path).'
+
+                if (-not $PSBoundParameters.ContainsKey('Path'))
                 {
-                    Write-Verbose -Message 'Calling DscResource Test by Module Name (or Path).'
-
-                    if (-not $PSBoundParameters.ContainsKey('Path'))
-                    {
-                        $PSBoundParameters['Path'] = Join-Path -Path $MyInvocation.MyCommand.Module.ModuleBase -ChildPath 'Tests/QA'
-                    }
-
-                    $null = $PSBoundParameters.Remove('Module')
-
-                    $ModuleUnderTest = Import-Module -Name $Module -ErrorAction 'Stop' -Force -PassThru
+                    $PSBoundParameters['Path'] = Join-Path -Path $MyInvocation.MyCommand.Module.ModuleBase -ChildPath 'Tests/QA'
                 }
 
-                'ByModuleSpecification'
+                $null = $PSBoundParameters.Remove('Module')
+
+                $ModuleUnderTest = Import-Module -Name $Module -ErrorAction 'Stop' -Force -PassThru
+            }
+
+            'ByModuleSpecification'
+            {
+                Write-Verbose -Message 'Calling DscResource Test by Module Specification.'
+
+                if (-not $PSBoundParameters.ContainsKey('Path'))
                 {
-                    Write-Verbose -Message 'Calling DscResource Test by Module Specification.'
-
-                    if (-not $PSBoundParameters.ContainsKey('Path'))
-                    {
-                        $PSBoundParameters['Path'] = Join-Path -Path $MyInvocation.MyCommand.Module.ModuleBase -ChildPath 'Tests/QA'
-                    }
-
-                    $null = $PSBoundParameters.Remove('FullyQualifiedModule')
-
-                    $ModuleUnderTest = Import-Module -FullyQualifiedName $FullyQualifiedModule -Force -PassThru -ErrorAction 'Stop'
+                    $PSBoundParameters['Path'] = Join-Path -Path $MyInvocation.MyCommand.Module.ModuleBase -ChildPath 'Tests/QA'
                 }
 
-                'ByProjectPath'
+                $null = $PSBoundParameters.Remove('FullyQualifiedModule')
+
+                $ModuleUnderTest = Import-Module -FullyQualifiedName $FullyQualifiedModule -Force -PassThru -ErrorAction 'Stop'
+            }
+
+            'ByProjectPath'
+            {
+                Write-Verbose -Message 'Calling DscResource Test by Project Path.'
+
+                if (-not $ProjectPath)
                 {
-                    Write-Verbose -Message 'Calling DscResource Test by Project Path.'
+                    $ProjectPath = $PWD.Path
+                }
 
-                    if (-not $ProjectPath)
-                    {
-                        $ProjectPath = $PWD.Path
-                    }
+                try
+                {
+                    $null = $PSBoundParameters.Remove('ProjectPath')
+                }
+                catch
+                {
+                    Write-Debug -Message 'The function was called via default param set. Using $PWD for Project Path.'
+                }
 
-                    try
-                    {
-                        $null = $PSBoundParameters.Remove('ProjectPath')
-                    }
-                    catch
-                    {
-                        Write-Debug -Message 'The function was called via default param set. Using $PWD for Project Path.'
-                    }
+                if (-not $PSBoundParameters.ContainsKey('Path'))
+                {
+                    $PSBoundParameters['Path'] = Join-Path -Path $MyInvocation.MyCommand.Module.ModuleBase -ChildPath 'Tests/QA'
+                }
 
-                    if (-not $PSBoundParameters.ContainsKey('Path'))
-                    {
-                        $PSBoundParameters['Path'] = Join-Path -Path $MyInvocation.MyCommand.Module.ModuleBase -ChildPath 'Tests/QA'
-                    }
-
-                    # Find the Source Manifest under ProjectPath
-                    $SourceManifest = ((Get-ChildItem -Path "$ProjectPath\*\*.psd1").Where{
-                            ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-                            $(
-                                try
-                                {
-                                    Test-ModuleManifest -Path $_.FullName -ErrorAction 'Stop'
-                                }
-                                catch
-                                {
-                                    $false
-                                }
-                            )
-                        }
-                    )
-
-                    $SourcePath = $SourceManifest.Directory.FullName
-                    $OutputPath = Join-Path -Path $ProjectPath -ChildPath 'output'
-
-                    $GetOutputModuleParams = @{
-                        Path        = $OutputPath
-                        Include     = $SourceManifest.Name
-                        Name        = $true # Or it doesn't behave properly on PS5.1
-                        Exclude     = 'RequiredModules'
-                        ErrorAction = 'Stop'
-                        Depth       = 3
-                    }
-
-                    Write-Verbose -Message (
-                        "Finding Output Module with `r`n {0}" -f (
-                            $GetOutputModuleParams | Format-Table -Property * -AutoSize | Out-String
+                # Find the Source Manifest under ProjectPath
+                $SourceManifest = ((Get-ChildItem -Path "$ProjectPath\*\*.psd1").Where{
+                        ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
+                        $(
+                            try
+                            {
+                                Test-ModuleManifest -Path $_.FullName -ErrorAction 'Stop'
+                            }
+                            catch
+                            {
+                                $false
+                            }
                         )
+                    }
+                )
+
+                $SourcePath = $SourceManifest.Directory.FullName
+                $OutputPath = Join-Path -Path $ProjectPath -ChildPath 'output'
+
+                $GetOutputModuleParams = @{
+                    Path        = $OutputPath
+                    Include     = $SourceManifest.Name
+                    Name        = $true # Or it doesn't behave properly on PS5.1
+                    Exclude     = 'RequiredModules'
+                    ErrorAction = 'Stop'
+                    Depth       = 3
+                }
+
+                Write-Verbose -Message (
+                    "Finding Output Module with `r`n {0}" -f (
+                        $GetOutputModuleParams | Format-Table -Property * -AutoSize | Out-String
                     )
-
-                    $modulePsd1 = Join-Path -Path $OutputPath -ChildPath (
-                        Get-ChildItem @GetOutputModuleParams |
-                            Select-Object -First 1
-                    )
-
-                    <#
-                        Importing the module psd1 ensures the filtered Import-Module
-                        passthru returns only one PSModuleInfo Object: Issue #71
-                    #>
-                    $dataFileImport = Import-PowerShellDataFile -Path $modulePsd1
-
-                    Write-Verbose -Message "Loading $modulePsd1."
-
-                    $ModuleUnderTest = Import-Module -Name $modulePsd1 -ErrorAction 'Stop' -PassThru |
-                        Where-Object -FilterScript {
-                            $PSItem.Guid -eq $dataFileImport['GUID']
-                        }
-                }
-            }
-
-            $ExcludeSourceFile = foreach ($projectFileOrFolder in $ExcludeSourceFile)
-            {
-                if (-not [System.String]::IsNullOrEmpty($projectFileOrFolder) -and -not (Split-Path -IsAbsolute $projectFileOrFolder))
-                {
-                    Join-Path -Path $SourcePath -ChildPath $projectFileOrFolder
-                }
-                elseif (-not [System.String]::IsNullOrEmpty($projectFileOrFolder))
-                {
-                    $projectFileOrFolder
-                }
-            }
-
-            if ($PSBoundParameters.ContainsKey('ExcludeSourceFile'))
-            {
-                $null = $PSBoundParameters.Remove('ExcludeSourceFile')
-            }
-
-            $ExcludeModuleFile = foreach ($moduleFileOrFolder in $ExcludeModuleFile)
-            {
-                if (-not [System.String]::IsNullOrEmpty($moduleFileOrFolder) -and -not (Split-Path -IsAbsolute $moduleFileOrFolder))
-                {
-                    Join-Path -Path $ModuleUnderTest.ModuleBase -ChildPath $moduleFileOrFolder
-                }
-                elseif (-not [System.String]::IsNullOrEmpty($moduleFileOrFolder))
-                {
-                    $moduleFileOrFolder
-                }
-            }
-
-            if ($PSBoundParameters.ContainsKey('ExcludeModuleFile'))
-            {
-                $null = $PSBoundParameters.Remove('ExcludeModuleFile')
-            }
-
-
-            <#
-                In case of ByProjectPath Opt-ins will be done by tags:
-                The Describe Name will be one of the Tag for the Describe block
-                If a Opt-In file is found, it will default to auto-populate -Tag
-                (cumulative from Command parameters).
-            #>
-            if ($ProjectPath -and -not $PSBoundParameters.ContainsKey('TagFilter') -and -not $PSBoundParameters.ContainsKey('ExcludeTagFilter'))
-            {
-                $expectedMetaOptInFile = Join-Path -Path $ProjectPath -ChildPath '.MetaTestOptIn.json'
-
-                if ($PSCmdlet.ParameterSetName -eq 'ByProjectPath' -and (Test-Path -Path $expectedMetaOptInFile))
-                {
-                    Write-Verbose -Message "Loading OptIns from $expectedMetaOptInFile."
-
-                    $optIns = Get-StructuredObjectFromFile -Path $expectedMetaOptInFile -ErrorAction 'Stop'
-                }
-
-                # Opt-Outs should be preferred, and we can do similar ways with ExcludeTags
-                $expectedMetaOptOutFile = Join-Path -Path $ProjectPath -ChildPath '.MetaTestOptOut.json'
-
-                if ($PSCmdlet.ParameterSetName -eq 'ByProjectPath' -and (Test-Path -Path $expectedMetaOptOutFile))
-                {
-                    Write-Verbose -Message "Loading OptOuts from $expectedMetaOptOutFile."
-
-                    $optOuts = Get-StructuredObjectFromFile -Path $expectedMetaOptOutFile -ErrorAction 'Stop'
-                }
-            }
-
-            # For each Possible parameters, use BoundParameters if exists, or use $Settings.ParameterName if exists otherwise
-            $possibleParamName = $PSCmdlet.MyInvocation.MyCommand.Parameters.Name
-
-            foreach ($paramName in $possibleParamName)
-            {
-                if (
-                    -not $PSBoundParameters.ContainsKey($paramName) `
-                    -and ($paramValue = $Settings.($paramName))
                 )
-                {
-                    Write-Verbose -Message "Adding setting $paramName."
 
-                    $PSBoundParameters.Add($paramName, $paramValue)
-                }
-            }
-
-            $newTag = @()
-            $newExcludeTag = @()
-
-            # foreach OptIns, add them to `-Tag`, unless in the ExcludeTags or already in Tag
-            foreach ($optInTag in $optIns)
-            {
-                if (
-                    $optInTag -notin $PSBoundParameters['ExcludeTagFilter'] `
-                    -and $optInTag -notin $PSBoundParameters['TagFilter']
+                $modulePsd1 = Join-Path -Path $OutputPath -ChildPath (
+                    Get-ChildItem @GetOutputModuleParams |
+                        Select-Object -First 1
                 )
-                {
-                    Write-Debug -Message "Adding tag $optInTag."
-                    $newTag += $optInTag
-                }
-            }
 
-            if ($newTag.Count -gt 0)
+                <#
+                    Importing the module psd1 ensures the filtered Import-Module
+                    passthru returns only one PSModuleInfo Object: Issue #71
+                #>
+                $dataFileImport = Import-PowerShellDataFile -Path $modulePsd1
+
+                Write-Verbose -Message "Loading $modulePsd1."
+
+                $ModuleUnderTest = Import-Module -Name $modulePsd1 -ErrorAction 'Stop' -PassThru |
+                    Where-Object -FilterScript {
+                        $PSItem.Guid -eq $dataFileImport['GUID']
+                    }
+            }
+        }
+
+        $ModuleName = $ModuleUnderTest.Name
+        $ModuleBase = $ModuleUnderTest.ModuleBase
+
+        # ExcludeSourceFile may be used by the Pester test files, and will be sent as a parameter (container in v5)
+        $ExcludeSourceFile = foreach ($projectFileOrFolder in $ExcludeSourceFile)
+        {
+            if (-not [System.String]::IsNullOrEmpty($projectFileOrFolder) -and -not (Split-Path -IsAbsolute $projectFileOrFolder))
             {
-                $PSBoundParameters['TagFilter'] = $newTag
+                Join-Path -Path $SourcePath -ChildPath $projectFileOrFolder
             }
-
-            # foreach OptOuts, add them to `-ExcludeTag`, unless in `-Tag`
-            foreach ($optOutTag in $optOuts)
+            elseif (-not [System.String]::IsNullOrEmpty($projectFileOrFolder))
             {
-                if (
-                    $optOutTag -notin $PSBoundParameters['TagFilter'] `
-                    -and $optOutTag -notin $PSBoundParameters['ExcludeTagFilter']
-                )
-                {
-                    Write-Debug -Message "Adding ExcludeTag $optOutTag."
-
-                    $newExcludeTag += $optOutTag
-                }
+                $projectFileOrFolder
             }
+        }
 
-            if ($newExcludeTag.Count -gt 0)
+        # Remove ExcludeSourceFile from PSBoundParameters (so we can use PSBoundParameters directly to Invoke-Pester)
+        if ($PSBoundParameters.ContainsKey('ExcludeSourceFile'))
+        {
+            $null = $PSBoundParameters.Remove('ExcludeSourceFile')
+        }
+
+        # ExcludeModuleFile may be used by the Pester test files, and will be sent as a parameter (container in v5)
+        $ExcludeModuleFile = foreach ($moduleFileOrFolder in $ExcludeModuleFile)
+        {
+            if (-not [System.String]::IsNullOrEmpty($moduleFileOrFolder) -and -not (Split-Path -IsAbsolute $moduleFileOrFolder))
             {
-                $PSBoundParameters['ExcludeTagFilter'] = $newExcludeTag
+                Join-Path -Path $ModuleUnderTest.ModuleBase -ChildPath $moduleFileOrFolder
+            }
+            elseif (-not [System.String]::IsNullOrEmpty($moduleFileOrFolder))
+            {
+                $moduleFileOrFolder
+            }
+        }
+
+        # Remove ExcludeModuleFile from PSBoundParameters (so we can use PSBoundParameters directly to Invoke-Pester)
+        if ($PSBoundParameters.ContainsKey('ExcludeModuleFile'))
+        {
+            $null = $PSBoundParameters.Remove('ExcludeModuleFile')
+        }
+
+
+        <#
+            In case of ByProjectPath Opt-ins will be done by tags:
+            The Describe Name will be one of the Tag for the Describe block
+            If a Opt-In file is found, it will default to auto-populate -Tag
+            (cumulative from Command parameters).
+        #>
+        if ($ProjectPath -and -not $PSBoundParameters.ContainsKey('TagFilter') -and -not $PSBoundParameters.ContainsKey('ExcludeTagFilter'))
+        {
+            $expectedMetaOptInFile = Join-Path -Path $ProjectPath -ChildPath '.MetaTestOptIn.json'
+
+            if ($PSCmdlet.ParameterSetName -eq 'ByProjectPath' -and (Test-Path -Path $expectedMetaOptInFile))
+            {
+                Write-Verbose -Message "Loading OptIns from $expectedMetaOptInFile."
+
+                $optIns = Get-StructuredObjectFromFile -Path $expectedMetaOptInFile -ErrorAction 'Stop'
             }
 
-            <#
-                This won't display the warning message for the skipped blocks
-                But should save time by not running initialization code within a Describe Block
-                And we can add such warning if we create a static list of the things we can opt-in
-                I'd prefer to not keep anything static, and AST risks not to cover 100% (maybe...), and OptOut is preferred
+            # Opt-Outs should be preferred, and we can do similar ways with ExcludeTags
+            $expectedMetaOptOutFile = Join-Path -Path $ProjectPath -ChildPath '.MetaTestOptOut.json'
 
-                Most tests should run against the built module
-                PSSA could be run against source, or against built module & convert lines/file
-            #>
+            if ($PSCmdlet.ParameterSetName -eq 'ByProjectPath' -and (Test-Path -Path $expectedMetaOptOutFile))
+            {
+                Write-Verbose -Message "Loading OptOuts from $expectedMetaOptOutFile."
 
-            $ModuleUnderTestManifest = Join-Path -Path $ModuleUnderTest.ModuleBase -ChildPath "$($ModuleUnderTest.Name).psd1"
+                $optOuts = Get-StructuredObjectFromFile -Path $expectedMetaOptOutFile -ErrorAction 'Stop'
+            }
+        }
 
+        # For each Possible parameters, use BoundParameters if exists, or use $Settings.ParameterName if exists otherwise
+        $possibleParamName = $PSCmdlet.MyInvocation.MyCommand.Parameters.Name
+
+        foreach ($paramName in $possibleParamName)
+        {
+            if (
+                -not $PSBoundParameters.ContainsKey($paramName) `
+                -and ($paramValue = $Settings.($paramName))
+            )
+            {
+                Write-Verbose -Message "Adding setting $paramName."
+
+                $PSBoundParameters.Add($paramName, $paramValue)
+            }
+        }
+
+        $newTag = @()
+        $newExcludeTag = @()
+
+        # foreach OptIns, add them to `-Tag`, unless in the ExcludeTags or already in Tag
+        foreach ($optInTag in $optIns)
+        {
+            if (
+                $optInTag -notin $PSBoundParameters['ExcludeTagFilter'] `
+                -and $optInTag -notin $PSBoundParameters['TagFilter']
+            )
+            {
+                Write-Debug -Message "Adding tag $optInTag."
+                $newTag += $optInTag
+            }
+        }
+
+        if ($newTag.Count -gt 0)
+        {
+            $PSBoundParameters['TagFilter'] = $newTag
+        }
+
+        # foreach OptOuts, add them to `-ExcludeTag`, unless in `-Tag`
+        foreach ($optOutTag in $optOuts)
+        {
+            if (
+                $optOutTag -notin $PSBoundParameters['TagFilter'] `
+                -and $optOutTag -notin $PSBoundParameters['ExcludeTagFilter']
+            )
+            {
+                Write-Debug -Message "Adding ExcludeTag $optOutTag."
+
+                $newExcludeTag += $optOutTag
+            }
+        }
+
+        if ($newExcludeTag.Count -gt 0)
+        {
+            $PSBoundParameters['ExcludeTagFilter'] = $newExcludeTag
+        }
+
+        <#
+            This won't display the warning message for the skipped blocks
+            But should save time by not running initialization code within a Describe Block
+            And we can add such warning if we create a static list of the things we can opt-in
+            I'd prefer to not keep anything static, and AST risks not to cover 100% (maybe...), and OptOut is preferred
+
+            Most tests should run against the built module
+            PSSA could be run against source, or against built module & convert lines/file
+        #>
+
+        $ModuleUnderTestManifest = Join-Path -Path $ModuleUnderTest.ModuleBase -ChildPath "$($ModuleUnderTest.Name).psd1"
+
+
+        if (-not $Pesterv5)
+        {
+            # In Pester v4, parameters are in hashtable with path @{Script = ''; Parameters = @{...}}
+            # In Pester v5 this is now in "Container"
             $ScriptItems = foreach ($item in $PSBoundParameters['Path'])
             {
                 if ($item -is [System.Collections.IDictionary])
@@ -414,6 +416,7 @@ function Invoke-DscResourceTest
                     {
                         $item['Parameters'] = @{ }
                     }
+
                     $item['Parameters']['ModuleBase'] = $ModuleUnderTest.ModuleBase
                     $item['Parameters']['ModuleName'] = $ModuleUnderTest.Name
                     $item['Parameters']['ModuleManifest'] = $ModuleUnderTestManifest
@@ -449,108 +452,127 @@ function Invoke-DscResourceTest
                 $item
             }
 
-            $PSBoundParameters['Path'] = $ScriptItems
+            $PSBoundParameters['Script'] = $ScriptItems
 
-            $invokePesterParameters = @{
-                PassThru = $PSBoundParameters.PassThru
-            }
-
-            $invokePesterParameters['Script'] = $PSBoundParameters.Path
-
-            if ($PSBoundParameters.ContainsKey('TestName'))
+            if ($PSBoundParameters.ContainsKey('Path'))
             {
-                $invokePesterParameters['TestName'] = $PSBoundParameters.TestName
+                $PSBoundParameters.Remove('Path')
             }
 
-            if ($PSBoundParameters.ContainsKey('EnableExit'))
-            {
-                $invokePesterParameters['EnableExit'] = $PSBoundParameters.EnableExit
-            }
-
+            # Remove Pester v5 specific parameter
             if ($PSBoundParameters.ContainsKey('TagFilter'))
             {
-                $invokePesterParameters['Tag'] = $PSBoundParameters.TagFilter
+                $PSBoundParameters['Tag'] = $PSBoundParameters['TagFilter']
+                $PSBoundParameters.Remove('TagFilter')
             }
 
             if ($PSBoundParameters.ContainsKey('ExcludeTagFilter'))
             {
-                $invokePesterParameters['ExcludeTag'] = $PSBoundParameters.ExcludeTagFilter
+                $PSBoundParameters['ExcludeTag'] = $PSBoundParameters['ExcludeTagFilter']
+                $PSBoundParameters.Remove('ExcludeTagFilter')
             }
 
-            if ($PSBoundParameters.ContainsKey('OutputFile'))
+            if ($PSBoundParameters.ContainsKey('Configuration'))
             {
-                $invokePesterParameters['OutputFile'] = $PSBoundParameters.OutputFile
-            }
-
-            if ($PSBoundParameters.ContainsKey('OutputFormat'))
-            {
-                $invokePesterParameters['OutputFormat'] = $PSBoundParameters.OutputFormat
-            }
-
-            if ($PSBoundParameters.ContainsKey('CodeCoverage'))
-            {
-                $invokePesterParameters['CodeCoverage'] = $PSBoundParameters.CodeCoverage
-            }
-
-            if ($PSBoundParameters.ContainsKey('CodeCoverageOutputFile'))
-            {
-                $invokePesterParameters['CodeCoverageOutputFile'] = $PSBoundParameters.CodeCoverageOutputFile
-            }
-
-            if ($PSBoundParameters.ContainsKey('CodeCoverageOutputFileFormat'))
-            {
-                $invokePesterParameters['CodeCoverageOutputFileFormat'] = $PSBoundParameters.CodeCoverageOutputFileFormat
-            }
-
-            if ($PSBoundParameters.ContainsKey('PesterOption'))
-            {
-                $invokePesterParameters['PesterOption'] = $PSBoundParameters.PesterOption
-            }
-
-            if ($PSBoundParameters.ContainsKey('Show'))
-            {
-                $invokePesterParameters['Show'] = $PSBoundParameters.Show
+                $PSBoundParameters.Remove('Configuration')
             }
         }
         else
         {
             # Pester 5 tests
+            throw "TODO"
+            $PesterV5AdvancedConfig = @{
+                Run          = @{}
+                Filter       = @{}
+                CodeCoverage = @{}
+                TestResult   = @{}
+                Should       = @{}
+                Debug        = @{}
+                Output       = @{}
+            }
 
-            $invokePesterParameters = @{}
+            # Remove v4 deprecated parameters for v5 invocation (they're in $Configuration)
+            @(
+                'EnableExit',
+                'TagFilter',
+                'ExcludeTagFilter',
+                'CodeCoverage',
+                'CodeCoverageOutputFile',
+                'CodeCoverageOutputFileFormat',
+                'Strict',
+                'Output',
+                'OutputFile',
+                'OutputFormat',
+                'Quiet',
+                'PesterOption',
+                'Show',
+                'MainGitBranch'
+            ).ForEach{
+                if ($PSBoundParameters.ContainsKey($_))
+                {
+                    switch ($_) {
+                        'EnableExit' { $PesterV5AdvancedConfig['Run']['EnableExit'] = $PSBoundParameters[$_]  }
+
+                        'TagFilter' {
+                            $PesterV5AdvancedConfig['Filter']['Tag'] = $PSBoundParameters[$_]
+                        }
+
+                        'ExcludeTagFilter' {
+                            $PesterV5AdvancedConfig['Filter']['ExcludeTag'] = $PSBoundParameters[$_]
+                        }
+
+                        'Output' {
+                            $PesterV5AdvancedConfig['Output']['Verbosity'] = $PSBoundParameters[$_]
+                        }
+
+                        'CodeCoverage' {
+                            $PesterV5AdvancedConfig['CodeCoverage']['Enabled'] = $true
+                            $PesterV5AdvancedConfig['CodeCoverage']['Path'] = $PSBoundParameters[$_]
+                        }
+
+                        'CodeCoverageOutputFile' {
+                            $PesterV5AdvancedConfig['CodeCoverage']['OutputPath'] = $PSBoundParameters[$_]
+                        }
+
+                        'CodeCoverageOutputFileFormat' {
+                            $PesterV5AdvancedConfig['CodeCoverage']['CodeCoverageOutputFileFormat'] = $PSBoundParameters[$_]
+                        }
+
+                        'OutputFile' {
+                            $PesterV5AdvancedConfig['TestResult']['OutputFile'] = $PSBoundParameters[$_]
+                        }
+
+                        'OutputFormat' {
+                            $PesterV5AdvancedConfig['TestResult']['OutputFormat'] = $PSBoundParameters[$_]
+                        }
+
+                        'Quiet' {
+                            $PesterV5AdvancedConfig['Output']['Verbosity'] = 'none'
+                        }
+
+                        'Show' {
+                            $PesterV5AdvancedConfig['Output']['Verbosity'] = $PSBoundParameters[$_]
+                        }
+                    }
+
+                    $PSBoundParameters.Remove($_)
+                }
+            }
 
             $getDscResourceTestContainerParameters = @{
-                ProjectPath       = $ProjectPath
-                ModuleName        = $ModuleName
-                DefaultBranch     = $MainGitBranch
-                SourcePath        = $SourcePath
-                ExcludeSourceFile = $ExcludeSourceFile
                 ModuleBase        = $ModuleBase
+                ModuleName        = $ModuleName
+                # ModuleManifest    = $ModuleUnderTestManifest
+                ProjectPath       = $ProjectPath
+                SourcePath        = $SourcePath
+                # SourceManifest   = $SourceManifest.FullName
                 ExcludeModuleFile = $ExcludeModuleFile
+                ExcludeSourceFile = $ExcludeSourceFile
+                DefaultBranch     = $MainGitBranch
             }
 
             $container = Get-DscResourceTestContainer @getDscResourceTestContainerParameters
-
-            $invokePesterParameters['Container'] = $container
-
-            if ($PSBoundParameters.ContainsKey('Output'))
-            {
-                $invokePesterParameters['Output'] = $Output
-            }
-
-            if ($PSBoundParameters.ContainsKey('ExcludeTagFilter'))
-            {
-                $invokePesterParameters['ExcludeTagFilter'] = $ExcludeTagFilter
-            }
-
-            if ($PSBoundParameters.ContainsKey('TagFilter'))
-            {
-                $invokePesterParameters['TagFilter'] = $TagFilter
-            }
-
-            if ($PSBoundParameters.ContainsKey('PassThru'))
-            {
-                $invokePesterParameters['PassThru'] = $PassThru
-            }
+            $PSBoundParameters['Container'] = $container
         }
 
         # Below is default command proxy handling
@@ -566,7 +588,7 @@ function Invoke-DscResourceTest
             $wrappedCmd = Get-Command -CommandType 'Function' -Name 'Invoke-Pester'
 
             $scriptCmd = {
-                & $wrappedCmd @invokePesterParameters
+                & $wrappedCmd @PSBoundParameters
             }
 
             $steppablePipeline = $scriptCmd.GetSteppablePipeline()

--- a/source/Public/Invoke-DscResourceTest.ps1
+++ b/source/Public/Invoke-DscResourceTest.ps1
@@ -480,7 +480,6 @@ function Invoke-DscResourceTest
         else
         {
             # Pester 5 tests
-            throw "TODO"
             $PesterV5AdvancedConfig = @{
                 Run          = @{}
                 Filter       = @{}
@@ -563,12 +562,22 @@ function Invoke-DscResourceTest
                 ModuleBase        = $ModuleBase
                 ModuleName        = $ModuleName
                 # ModuleManifest    = $ModuleUnderTestManifest
-                ProjectPath       = $ProjectPath
-                SourcePath        = $SourcePath
+                # ProjectPath       = $ProjectPath
+                # SourcePath        = $SourcePath
                 # SourceManifest   = $SourceManifest.FullName
                 ExcludeModuleFile = $ExcludeModuleFile
                 ExcludeSourceFile = $ExcludeSourceFile
                 DefaultBranch     = $MainGitBranch
+            }
+
+            if ($ProjectPath)
+            {
+                $getDscResourceTestContainerParameters.Add('ProjectPath',$ProjectPath)
+            }
+
+            if ($SourcePath)
+            {
+                $getDscResourceTestContainerParameters.Add('SourcePath', $SourcePath)
             }
 
             $container = Get-DscResourceTestContainer @getDscResourceTestContainerParameters

--- a/source/Tests/QA/Changelog.common.v5.Tests.ps1
+++ b/source/Tests/QA/Changelog.common.v5.Tests.ps1
@@ -14,7 +14,7 @@
 #>
 param
 (
-    [Parameter(Mandatory = $true)]
+    [Parameter()]
     [System.String]
     $ProjectPath,
 

--- a/source/Tests/QA/ExampleFiles.common.v5.Tests.ps1
+++ b/source/Tests/QA/ExampleFiles.common.v5.Tests.ps1
@@ -13,7 +13,7 @@
 #>
 param
 (
-    [Parameter(Mandatory = $true)]
+    [Parameter()]
     [System.String]
     $SourcePath,
 
@@ -37,7 +37,12 @@ if (-not $isPester5)
 
 BeforeDiscovery {
     # Re-imports the private (and public) functions.
-    Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '../../DscResource.Test.psm1') -Force
+    Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '../../DscResource.Test.psm1')
+
+    if (-not $SourcePath)
+    {
+        return
+    }
 
     $examplesPath = Join-Path -Path $SourcePath -ChildPath 'Examples'
 

--- a/source/Tests/QA/FileFormatting.common.v5.Tests.ps1
+++ b/source/Tests/QA/FileFormatting.common.v5.Tests.ps1
@@ -17,7 +17,7 @@
 #>
 param
 (
-    [Parameter(Mandatory = $true)]
+    [Parameter()]
     [System.String]
     $ProjectPath,
 
@@ -53,7 +53,7 @@ if (-not $isPester5)
 
 BeforeDiscovery {
     # Re-imports the private (and public) functions.
-    Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '../../DscResource.Test.psm1') -Force
+    Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '../../DscResource.Test.psm1')
 
     $textFiles = @(Get-TextFilesList -Root $ModuleBase | WhereModuleFileNotExcluded -ExcludeModuleFile $ExcludeModuleFile)
 
@@ -62,8 +62,15 @@ BeforeDiscovery {
         $textFiles += Get-TextFilesList -Root $SourcePath | WhereSourceFileNotExcluded -ExcludeSourceFile $ExcludeSourceFile
     }
 
-    # Expand the project folder if it is a relative path.
-    $resolvedProjectPath = (Resolve-Path -Path $ProjectPath).Path
+    if ($ProjectPath)
+    {
+        # Expand the project folder if it is a relative path.
+        $resolvedProjectPath = (Resolve-Path -Path $ProjectPath).Path
+    }
+    else
+    {
+        $resolvedProjectPath = $ModuleBase
+    }
 
     #region Setup text file test cases.
     $textFileToTest = @()

--- a/source/Tests/QA/Localization.common.v5.Tests.ps1
+++ b/source/Tests/QA/Localization.common.v5.Tests.ps1
@@ -48,7 +48,7 @@ if (-not $isPester5)
 
 BeforeDiscovery {
     # Re-imports the private (and public) functions.
-    Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '../../DscResource.Test.psm1') -Force
+    Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '../../DscResource.Test.psm1')
 
     $moduleFiles = @(Get-ChildItem -Path $ModuleBase -Filter '*.psm1' -Recurse | WhereModuleFileNotExcluded -ExcludeModuleFile $ExcludeModuleFile)
 

--- a/source/Tests/QA/MarkdownLinks.common.v5.Tests.ps1
+++ b/source/Tests/QA/MarkdownLinks.common.v5.Tests.ps1
@@ -17,7 +17,7 @@
 #>
 param
 (
-    [Parameter(Mandatory = $true)]
+    [Parameter()]
     [System.String]
     $ProjectPath,
 
@@ -52,6 +52,12 @@ if (-not $isPester5)
 }
 
 BeforeDiscovery {
+    if (-not $ProjectPath)
+    {
+        Write-Verbose -Message 'The Markdown links check only applies when testing a Source repository'
+        return
+    }
+
     <#
         This check need to be done in discovery otherwise the tests will
         fail when pester does "Run" on the missing cmdlet Get-MarkdownLink.

--- a/source/Tests/QA/ModuleScriptFiles.common.v5.Tests.ps1
+++ b/source/Tests/QA/ModuleScriptFiles.common.v5.Tests.ps1
@@ -17,7 +17,7 @@
 #>
 param
 (
-    [Parameter(Mandatory = $true)]
+    [Parameter()]
     [System.String]
     $ProjectPath,
 
@@ -62,8 +62,15 @@ BeforeDiscovery {
         $moduleFiles += @(Get-ChildItem -Path $SourcePath -Filter '*.psm1' -Recurse | WhereSourceFileNotExcluded -ExcludeSourceFile $ExcludeSourceFile)
     }
 
-    # Expand the project folder if it is a relative path.
-    $resolvedProjectPath = (Resolve-Path -Path $ProjectPath).Path
+    if ($ProjectPath)
+    {
+        # Expand the project folder if it is a relative path.
+        $resolvedProjectPath = (Resolve-Path -Path $ProjectPath).Path
+    }
+    else
+    {
+        $resolvedProjectPath = $ModuleBase
+    }
 
     $moduleFileToTest = @()
 

--- a/source/Tests/QA/PSSAResource.common.v5.Tests.ps1
+++ b/source/Tests/QA/PSSAResource.common.v5.Tests.ps1
@@ -17,7 +17,7 @@
 #>
 param
 (
-    [Parameter(Mandatory = $true)]
+    [Parameter()]
     [System.String]
     $ProjectPath,
 
@@ -78,8 +78,15 @@ BeforeDiscovery {
         $moduleFiles += @(Get-ChildItem -Path $SourcePath -Filter '*.psm1' -Recurse | WhereSourceFileNotExcluded -ExcludeSourceFile $ExcludeSourceFile)
     }
 
-    # Expand the project folder if it is a relative path.
-    $resolvedProjectPath = (Resolve-Path -Path $ProjectPath).Path
+    if ($ProjectPath)
+    {
+        # Expand the project folder if it is a relative path.
+        $resolvedProjectPath = (Resolve-Path -Path $ProjectPath).Path
+    }
+    else
+    {
+        $resolvedProjectPath = $ModuleBase
+    }
 
     $moduleFileToTest = @()
 

--- a/source/Tests/QA/PublishExampleFiles.common.v5.Tests.ps1
+++ b/source/Tests/QA/PublishExampleFiles.common.v5.Tests.ps1
@@ -14,7 +14,7 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingEmptyCatchBlock', '')]
 param
 (
-    [Parameter(Mandatory = $true)]
+    [Parameter()]
     [System.String]
     $SourcePath,
 
@@ -33,6 +33,11 @@ $isPester5 = (Get-Module -Name Pester).Version -ge '5.1.0'
 if (-not $isPester5)
 {
     Write-Verbose -Message 'Repository is using old Pester version, new HQRM tests for Pester 5 are skipped.' -Verbose
+    return
+}
+
+if (-not $SourcePath) {
+    Write-Verbose -Message 'The Publish Example files tests only apply to Source repository testing.'
     return
 }
 

--- a/tests/Unit/Public/Invoke-DscResourceTest.Tests.ps1
+++ b/tests/Unit/Public/Invoke-DscResourceTest.Tests.ps1
@@ -93,13 +93,13 @@ InModuleScope $ProjectName {
 
             It 'works when using an existing module' {
                 {
-                    Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing -Verbose
+                    Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing #-verbose
                 } | Should -Not -Throw
                 Assert-MockCalled -CommandName Get-Command -Scope It
             }
 
             It 'Should call Invoke-Pester with correct parameters' {
-                $result = Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing -Verbose
+                $result = Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing #-verbose
                 $result.Script.Path | Should -BeExactly '.'
                 $result.Script.Parameters.ModuleName | Should -BeExactly 'Microsoft.PowerShell.Utility'
                 $result.Script.Parameters.keys | Should -HaveCount 11
@@ -110,7 +110,7 @@ InModuleScope $ProjectName {
 
         Context 'When with alternate MainGitBranch' {
             It 'Should call Invoke-Pester with correct parameters' {
-                $result = Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing -MainGitBranch 'main' -Verbose
+                $result = Invoke-DscResourceTest -Module Microsoft.PowerShell.Utility -Script '.' -Tag nothing -MainGitBranch 'main' #-verbose
                 $result.Script.Path | Should -BeExactly '.'
                 $result.Script.Parameters.ModuleName | Should -BeExactly 'Microsoft.PowerShell.Utility'
                 $result.Script.Parameters.keys | Should -HaveCount 11
@@ -153,7 +153,7 @@ InModuleScope $ProjectName {
             }
 
             It 'Should invoke pester using correct parameters when using an existing module path' {
-                $result = Invoke-DscResourceTest -Module 'C:\MyModuleNameDoesNotExist.psd1' -Verbose
+                $result = Invoke-DscResourceTest -Module 'C:\MyModuleNameDoesNotExist.psd1' #-verbose
                 $result.Script.Parameters.ProjectPath | Should -BeNullOrEmpty
                 $result.Script.Parameters.ModuleName | Should -BeExactly 'C:\MyModuleNameDoesNotExist.psd1'
             }
@@ -164,7 +164,7 @@ InModuleScope $ProjectName {
                 ModuleName    = 'Microsoft.PowerShell.Utility'
                 ModuleVersion = '1.0.0.0'
             }
-            $result = Invoke-DscResourceTest -FullyQualifiedModule $FQM -Script . -Verbose
+            $result = Invoke-DscResourceTest -FullyQualifiedModule $FQM -Script . #-verbose
             $result.Script.Path | Should -BeExactly '.'
             $result.Script.Parameters.ModuleName | Should -BeExactly 'Microsoft.PowerShell.Utility'
             $result.Script.Parameters.keys | Should -HaveCount 11
@@ -216,7 +216,7 @@ InModuleScope $ProjectName {
         }
 
         It 'Should override properly the Script parameters for Invoke-Pester' {
-            $result = Invoke-DscResourceTest -ProjectPath $PSScriptRoot\..\assets -Verbose
+            $result = Invoke-DscResourceTest -ProjectPath $PSScriptRoot\..\assets #-verbose
             Assert-MockCalled Get-Command -Scope Describe
             $result.Script.Parameters.ModuleName | Should -Not -BeExactly 'dummy'
             $result.script.Parameters.Keys | Should -HaveCount 11
@@ -246,7 +246,7 @@ InModuleScope $ProjectName {
                 Parameters = @{
                     'ModuleName' = 'dummy'
                 }
-            } -Module 'Microsoft.PowerShell.Utility'  -Verbose
+            } -Module 'Microsoft.PowerShell.Utility'  #-verbose
             $result.Script.Parameters.ModuleName | Should -Not -BeExactly 'dummy'
             $result.script.Parameters.Keys | Should -HaveCount 11
         }


### PR DESCRIPTION
Now I can do this: `ipmo Pester -Min 5.1; Invoke-DscResourceTest -Module Sampler -Verbose`

It will check the Sampler module if available and  exclude the tests that need ProjectPath or SourcePath.
It's a good way to validate any module against DSC community rules, even without the same repository layout.